### PR TITLE
Rename version to SNAPSHOT instead of non-maven standard SNAPTSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>JDBM</groupId>
     <artifactId>JDBM</artifactId>
-    <version>3.0-SNAPTSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 
 
     <developers>


### PR DESCRIPTION
Just a small fix which should improve my maven dependency info. Thanks!
