### PR TITLE
Avoiding throwing an exception for fields that do not exist anymore

### DIFF
--- a/src/main/java/net/kotek/jdbm/SerialClassInfo.java
+++ b/src/main/java/net/kotek/jdbm/SerialClassInfo.java
@@ -252,8 +252,8 @@ abstract class SerialClassInfo {
             //move to superclass
             clazz = clazz.getSuperclass();
         }
-        throw new NoSuchFieldError(object.getClass() + "." + fieldName);
-
+        // ignore field if it does not exist anymore
+        //throw new NoSuchFieldError(object.getClass() + "." + fieldName);
     }
 
 

--- a/src/test/java/net/kotek/jdbm/SerialClassInfoTest.java
+++ b/src/test/java/net/kotek/jdbm/SerialClassInfoTest.java
@@ -144,6 +144,12 @@ public class SerialClassInfoTest extends TestCaseWithTestFile {
         assertEquals("zz", b2.field3);
     }
 
+    public void testSetFieldValue_IgnoresNonExistingFields() {
+        s.setFieldValue("field_does_not_exist", b2, "zzz");
+        s.setFieldValue("field3", b2, "zz");
+        assertEquals("zz", b2.field3);
+    }
+    
     public void testGetPrimitiveField() {
         assertEquals(Integer.MAX_VALUE, s.getFieldValue("intField", b2));
         assertEquals(Long.MAX_VALUE, s.getFieldValue("longField", b2));


### PR DESCRIPTION
I think it would be easier to evolve objects if the deserializer would ignore fields that do not exist anymore. I know that JAXB and similar frameworks work this way.
