### PR TITLE
closeOnJVMExit Should be Runtime.getRuntime().addShutdownHook(t);

### DIFF
--- a/src/main/java/net/kotek/jdbm/DBMaker.java
+++ b/src/main/java/net/kotek/jdbm/DBMaker.java
@@ -327,7 +327,7 @@ public class DBMaker {
                     db2.close();    
               }
             };
-            Runtime.getRuntime().removeShutdownHook(t);
+            Runtime.getRuntime().addShutdownHook(t);
         }
 
         return db;


### PR DESCRIPTION
closeOnJVMExit Should be Runtime.getRuntime().addShutdownHook(t);
