### PR TITLE
It's exceptionally rare to have a Maven artifact with capitalization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>JDBM</groupId>
-    <artifactId>JDBM</artifactId>
+    <groupId>jdbm</groupId>
+    <artifactId>jdbm</artifactId>
     <version>3.0-SNAPSHOT</version>
 
 


### PR DESCRIPTION
so lowercase the group and artifact ID.

Following convention makes it much less surprising when you write a dependency on "jdbm" and it doesn't work because the pom specifies "JDBM"
