### PR TITLE
Made DataInputOutput public to allow easy custom serializers

### DIFF
--- a/src/main/java/org/apache/jdbm/DataInputOutput.java
+++ b/src/main/java/org/apache/jdbm/DataInputOutput.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
  *
  * @author Jan Kotek
  */
-class DataInputOutput implements DataInput, DataOutput, ObjectInput, ObjectOutput {
+public class DataInputOutput implements DataInput, DataOutput, ObjectInput, ObjectOutput {
 
     private int pos = 0;
     private int count = 0;


### PR DESCRIPTION
I found it quite messy to implement a custom deserializer due to the fact that only DataInput is exposed (not even DataInputStream) rather than DataInputOutput, which is what the instance really is.

Because DataInputOutput isn't public, I wasn't able to cast the DataInput, and therefore had to manually consume the stream at the lowest level (ie: construct byte arrays and manipulate) - ie:

``` java
        @Override
        public SomeClass deserialize(DataInput in) throws IOException, ClassNotFoundException {
            // DataInput is very restrictive, no access to toByteArray(), etc, etc
            byte[] muchEasier = ((DataInputOutput) in).toByteArray();
        }

```

It's much easier if DataInputOutput is exposed (or even if the interface passed in DataInputOutput rather than DataInput).

Cheers! (and thanks for a great library)
