### PR TITLE
Updated README code example to reflect API changes and Changed groupid to org.apache.jdbm

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ JDBM is not currently in any Maven repository. TODO: We should have soon custom 
 Quick example
 -------------
 
-    import net.kotek.jdbm.*;
+    import org.apache.jdbm.*;
 
     //Open database using builder pattern. 
     //All options are available with code autocompletion.

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ Quick example
     //Open database using builder pattern. 
     //All options are available with code autocompletion.
     DB db = DBMaker.openFile("test")  
-        .deleteAfterClose()
+        .deleteFilesAfterClose()
         .enableEncryption("password",false)
         .make();
   
     //open an collection, TreeMap has better performance then HashMap
-    SortedMap<Integer,String> map = db.createMap("collectionName");
+    SortedMap<Integer,String> map = db.createTreeMap("collectionName");
 
     map.put(1,"one");
     map.put(2,"two");

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>jdbm</groupId>
+    <groupId>org.apache.jdbm</groupId>
     <artifactId>jdbm</artifactId>
     <version>3.0-SNAPSHOT</version>
 


### PR DESCRIPTION
Updated README as the code sample provided was not working anymore.

As per maven naming guidelines [http://maven.apache.org/guides/mini/guide-naming-conventions.html] , groupid should be updated from

```
    <groupId>jdbm</groupId>
    <artifactId>jdbm</artifactId>
```

to:

```
    <groupId>org.apache.jdbm</groupId>
    <artifactId>jdbm</artifactId>
```

unless there is some specific reason for not updating it.
