### PR TITLE
Github mvn repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.project
+.settings
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,16 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<github.global.server>github</github.global.server>
     </properties>
+	
+	<distributionManagement>
+	    <repository>
+	        <id>internal.repo</id>
+			<name>Temporary Staging Repository</name>
+			<url>file://${project.build.directory}/mvn-repo</url>
+		</repository>
+	</distributionManagement>
 
     <dependencies>
         <dependency>
@@ -72,6 +81,28 @@
                     </execution>
                 </executions>
             </plugin>
+        <plugin>
+            <groupId>com.github.github</groupId>
+            <artifactId>site-maven-plugin</artifactId>
+            <version>0.7</version>
+            <configuration>
+                <message>Maven artifacts for ${project.version}</message>  
+                <noJekyll>true</noJekyll>                                  
+                <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory> 
+                <branch>refs/heads/mvn-repo</branch>                     
+                <includes><include>**/*</include></includes>
+                <repositoryName>JDBM3</repositoryName>      
+                <repositoryOwner>TIQSolutions</repositoryOwner> 
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>site</goal>
+                </goals>
+                <phase>deploy</phase>
+              </execution>
+            </executions>
+        </plugin>
 <!-- uncomment to enable proguard (strip down jar)-->
 <!--
             <plugin>


### PR DESCRIPTION
Hey Jan,

I needed to retrieve your project as a dependency in one our projects using apache maven. I just saw in the README that you would like to publish the project via maven anyway - so I checked out this article: http://stackoverflow.com/questions/14013644/hosting-a-maven-repository-on-github/14013645#14013645 
and followed it's instructions. The result is a adjusted POM-file. Building the project with maven allows now to commit the deployable resources to a own branch during the deploy phase. This branch could be used in other maven projects like a repository. So I'm able to declare the project as a normal maven dependency in one of my projects: 

<dependency>
            <groupId>org.apache.jdbm</groupId>
            <artifactId>jdbm</artifactId>
            <version>3.0-SNAPSHOT</version>
        </dependency>

using repository: 

```
    <repository>
        <id>JDBM3-mvn-repo</id>
        <url>https://raw.github.com/TIQSolutions/JDBM3/mvn-repo/</url>
        <snapshots>
            <enabled>true</enabled>
            <updatePolicy>always</updatePolicy>
        </snapshots>
    </repository>
```

in the repositories section of the pom.xml.

I hope I could helped a bit.

Sincerly,

D. Häberlein 
